### PR TITLE
Update sbt ci-release + CI/CD

### DIFF
--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -38,8 +36,6 @@ jobs:
           - 9084:9084 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           distribution: temurin

--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 21
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Run unit tests
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 21
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Run integration tests
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 21
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Deploy 

--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -7,16 +7,17 @@ on:
 jobs:
   unit-test:
     name: Run Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Run unit tests
         run: sbt cli/test
       - uses: actions/upload-artifact@v3
@@ -25,7 +26,7 @@ jobs:
           path: cli/target/test-reports/
   integration-test:
     name: Run Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: unit-test
     services:
       # Label used to access the service container
@@ -36,14 +37,15 @@ jobs:
         ports:
           - 9084:9084 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Run integration tests
         run: sbt "cli / IntegrationTest / test"
       - uses: actions/download-artifact@v3
@@ -59,16 +61,18 @@ jobs:
             cli/target/it-reports/**/*.xml
   publish:
     name: Deploy to Maven Central
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ unit-test, integration-test ]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v13
-      - uses: olafurpg/setup-gpg@v3
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Deploy 
         run: sbt "buildClient; ci-release"
         env:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.4")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.5")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.14.0")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")


### PR DESCRIPTION
## Purpose
Fix the release process + update CI/CD to recommended settings for sbt ci-release.

The release process is failing https://github.com/PlasmaLaboratories/plasma-cli/actions/runs/11486989313/job/32012793657

After comparing to the sdk repo, it seems that the gpg key was not properly getting installed correctly. After digging into why, I discovered the following:

* We were using `ubuntu-20.04` which already has gpg installed (sdk uses ubuntu-latest)
* The `setup-gpg` action appears to not even be doing anything.
* The recommended GitHub action yaml for sbt ci-release has been updated since it was last set up: https://github.com/sbt/sbt-ci-release/blob/main/.github/workflows/release.yml

## Approach
* Update the sbt ci-release plugin
* Update github runner version
* Update CI/CD to use recommended settings for releasing.

## Testing
Published to snapshot. I'll need to try another release to validate this works.

## Tickets
n/a