### PR TITLE
upgrade plasma-node 0.1.2

### DIFF
--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -30,7 +30,7 @@ jobs:
       # Label used to access the service container
       node:
         # Docker Hub image
-        image: ghcr.io/plasmalaboratories/plasma-node:0.1.0
+        image: ghcr.io/plasmalaboratories/plasma-node:0.1.2
         #
         ports:
           - 9084:9084 


### PR DESCRIPTION
## Purpose
upgrade plasma-node 0.1.2, (aka scala 3 migration, before protobuf-specs migration asset policies into datum)